### PR TITLE
Prevents unknown props ... on tag

### DIFF
--- a/src/ImmutableListView/EmptyListView.js
+++ b/src/ImmutableListView/EmptyListView.js
@@ -71,17 +71,9 @@ class EmptyListView extends PureComponent {
 
   render() {
     const { listData } = this.state;
-    const {
-      renderEmpty, renderEmptyInList, renderSectionHeader, ...passThroughProps
-    } = this.props;
+    const { renderEmpty, renderEmptyInList, renderSectionHeader, emptyText, ...passThroughProps } = this.props;
 
-    return (
-      <ImmutableListView
-        renderRow={() => this.renderRow()}
-        {...passThroughProps}
-        immutableData={listData}
-      />
-    );
+    return <ImmutableListView renderRow={() => this.renderRow()} {...passThroughProps} immutableData={listData} />;
   }
 
 }

--- a/src/ImmutableListView/EmptyListView.js
+++ b/src/ImmutableListView/EmptyListView.js
@@ -71,9 +71,17 @@ class EmptyListView extends PureComponent {
 
   render() {
     const { listData } = this.state;
-    const { renderEmpty, renderEmptyInList, renderSectionHeader, emptyText, ...passThroughProps } = this.props;
+    const {
+      renderEmpty, renderEmptyInList, renderSectionHeader, emptyText, ...passThroughProps
+    } = this.props;
 
-    return <ImmutableListView renderRow={() => this.renderRow()} {...passThroughProps} immutableData={listData} />;
+    return (
+      <ImmutableListView
+        renderRow={() => this.renderRow()}
+        {...passThroughProps}
+        immutableData={listData}
+      />
+    );
   }
 
 }

--- a/src/ImmutableListView/ImmutableListView.js
+++ b/src/ImmutableListView/ImmutableListView.js
@@ -196,13 +196,25 @@ class ImmutableListView extends PureComponent {
 
   render() {
     const { dataSource } = this.state;
+    const {
+      immutableData,
+      renderEmpty,
+      renderEmptyInList,
+      rowsDuringInteraction,
+      sectionHeaderHasChanged,
+      ...passThroughProps
+    } = this.props;
 
-    return this.renderEmpty() || (
-      <ListView
-        ref={(component) => { this.listViewRef = component; }}
-        dataSource={dataSource}
-        {...this.props}
-      />
+    return (
+      this.renderEmpty() || (
+        <ListView
+          ref={(component) => {
+            this.listViewRef = component;
+          }}
+          dataSource={dataSource}
+          {...passThroughProps}
+        />
+      )
     );
   }
 

--- a/src/ImmutableListView/ImmutableListView.js
+++ b/src/ImmutableListView/ImmutableListView.js
@@ -197,24 +197,15 @@ class ImmutableListView extends PureComponent {
   render() {
     const { dataSource } = this.state;
     const {
-      immutableData,
-      renderEmpty,
-      renderEmptyInList,
-      rowsDuringInteraction,
-      sectionHeaderHasChanged,
-      ...passThroughProps
+      immutableData, renderEmpty, renderEmptyInList, rowsDuringInteraction, sectionHeaderHasChanged, ...passThroughProps
     } = this.props;
 
-    return (
-      this.renderEmpty() || (
-        <ListView
-          ref={(component) => {
-            this.listViewRef = component;
-          }}
-          dataSource={dataSource}
-          {...passThroughProps}
-        />
-      )
+    return this.renderEmpty() || (
+      <ListView
+        ref={(component) => { this.listViewRef = component; }}
+        dataSource={dataSource}
+        {...passThroughProps}
+      />
     );
   }
 

--- a/src/ImmutableListView/__tests__/__snapshots__/EmptyListView.test.js.snap
+++ b/src/ImmutableListView/__tests__/__snapshots__/EmptyListView.test.js.snap
@@ -8,17 +8,7 @@ exports[`EmptyListView renders with custom renderRow 1`] = `
       "items": 1,
     }
   }
-  emptyText="Nothing. Nothing at all."
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        undefined,
-        "Nothing. Nothing at all.",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -30,11 +20,9 @@ exports[`EmptyListView renders with custom renderRow 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -58,17 +46,7 @@ exports[`EmptyListView renders with custom text 1`] = `
       "items": 1,
     }
   }
-  emptyText="Nothing. Nothing at all."
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        undefined,
-        "Nothing. Nothing at all.",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -80,11 +58,9 @@ exports[`EmptyListView renders with custom text 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -114,17 +90,7 @@ exports[`EmptyListView renders with default text 1`] = `
       "items": 1,
     }
   }
-  emptyText="No data."
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        undefined,
-        "No data.",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -136,11 +102,9 @@ exports[`EmptyListView renders with default text 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >

--- a/src/ImmutableListView/__tests__/__snapshots__/ImmutableListView.test.js.snap
+++ b/src/ImmutableListView/__tests__/__snapshots__/ImmutableListView.test.js.snap
@@ -9,22 +9,6 @@ exports[`ImmutableListView renders Map: List rows, with section headers 1`] = `
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.Map {
-      "first": Immutable.List [
-        "m",
-        "a",
-        "p",
-      ],
-      "second": Immutable.List [
-        "foo",
-      ],
-      "third": Immutable.List [],
-      "fourth": Immutable.List [
-        "bar",
-      ],
-    }
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -36,12 +20,10 @@ exports[`ImmutableListView renders Map: List rows, with section headers 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   renderSectionHeader={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={
     Array [
       0,
@@ -133,22 +115,6 @@ exports[`ImmutableListView renders Map: List rows, without section headers 1`] =
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.Map {
-      "first": Immutable.List [
-        "m",
-        "a",
-        "p",
-      ],
-      "second": Immutable.List [
-        "foo",
-      ],
-      "third": Immutable.List [],
-      "fourth": Immutable.List [
-        "bar",
-      ],
-    }
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -160,11 +126,9 @@ exports[`ImmutableListView renders Map: List rows, without section headers 1`] =
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -210,15 +174,6 @@ exports[`ImmutableListView renders Map: Map rows, with section headers 1`] = `
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.Map {
-      "first": Immutable.Map {
-        "row1": "data 1",
-        "row2": "data 2",
-      },
-      "second": Immutable.Map {},
-    }
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -230,12 +185,10 @@ exports[`ImmutableListView renders Map: Map rows, with section headers 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   renderSectionHeader={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={
     Array [
       0,
@@ -288,15 +241,6 @@ exports[`ImmutableListView renders Map: Map rows, without section headers 1`] = 
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.Map {
-      "first": Immutable.Map {
-        "row1": "data 1",
-        "row2": "data 2",
-      },
-      "second": Immutable.Map {},
-    }
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -308,11 +252,9 @@ exports[`ImmutableListView renders Map: Map rows, without section headers 1`] = 
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -344,13 +286,6 @@ exports[`ImmutableListView renders basic List 1`] = `
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -362,11 +297,9 @@ exports[`ImmutableListView renders basic List 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -405,7 +338,6 @@ exports[`ImmutableListView renders basic Range 1`] = `
     }
   }
   enableEmptySections={true}
-  immutableData={Immutable.Seq […]}
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -417,11 +349,9 @@ exports[`ImmutableListView renders basic Range 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -460,13 +390,6 @@ exports[`ImmutableListView renders basic Set 1`] = `
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.Set [
-      "one",
-      "two",
-      "three",
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -478,11 +401,9 @@ exports[`ImmutableListView renders basic Set 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -521,18 +442,6 @@ exports[`ImmutableListView renders nested List 1`] = `
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Array [
-        "so",
-        "are",
-      ],
-      Array [
-        "nested",
-        "lists",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -544,11 +453,9 @@ exports[`ImmutableListView renders nested List 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -579,17 +486,7 @@ exports[`ImmutableListView renders with empty data 1`] = `
       "items": 1,
     }
   }
-  emptyText="No data."
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        "No data.",
-        "No data.",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -601,11 +498,9 @@ exports[`ImmutableListView renders with empty data 1`] = `
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -636,13 +531,6 @@ exports[`ImmutableListView with delayed rendering renders basic List after inter
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -654,12 +542,9 @@ exports[`ImmutableListView with delayed rendering renders basic List after inter
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
-  rowsDuringInteraction={1}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -698,13 +583,6 @@ exports[`ImmutableListView with delayed rendering renders basic List during inte
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -716,12 +594,9 @@ exports[`ImmutableListView with delayed rendering renders basic List during inte
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
-  rowsDuringInteraction={1}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -746,7 +621,6 @@ exports[`ImmutableListView with renderEmpty doesn't render empty with null 1`] =
     }
   }
   enableEmptySections={true}
-  immutableData={Immutable.List []}
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -758,12 +632,9 @@ exports[`ImmutableListView with renderEmpty doesn't render empty with null 1`] =
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmpty={null}
-  renderEmptyInList={null}
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -811,13 +682,6 @@ exports[`ImmutableListView with renderEmpty renders normally when there are some
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -829,12 +693,9 @@ exports[`ImmutableListView with renderEmpty renders normally when there are some
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmpty={[Function]}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -873,7 +734,6 @@ exports[`ImmutableListView with renderEmptyInList doesn't render empty with null
     }
   }
   enableEmptySections={true}
-  immutableData={Immutable.List []}
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -885,12 +745,9 @@ exports[`ImmutableListView with renderEmptyInList doesn't render empty with null
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmpty={null}
-  renderEmptyInList={null}
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -906,17 +763,7 @@ exports[`ImmutableListView with renderEmptyInList renders empty with a function 
       "items": 1,
     }
   }
-  emptyText="No data."
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        [Function],
-        "No data.",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -928,11 +775,9 @@ exports[`ImmutableListView with renderEmptyInList renders empty with a function 
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -961,17 +806,7 @@ exports[`ImmutableListView with renderEmptyInList renders empty with a string 1`
       "items": 1,
     }
   }
-  emptyText="No items"
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        "No items",
-        "No items",
-      ],
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -983,11 +818,9 @@ exports[`ImmutableListView with renderEmptyInList renders empty with a string 1`
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList="No data."
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >
@@ -1018,13 +851,6 @@ exports[`ImmutableListView with renderEmptyInList renders normally when there ar
     }
   }
   enableEmptySections={true}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialListSize={10}
   onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
@@ -1036,11 +862,9 @@ exports[`ImmutableListView with renderEmptyInList renders normally when there ar
   onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={false}
-  renderEmptyInList={[Function]}
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  sectionHeaderHasChanged={[Function]}
   stickyHeaderIndices={Array []}
   stickySectionHeadersEnabled={true}
 >

--- a/src/ImmutableVirtualizedList/EmptyVirtualizedList.js
+++ b/src/ImmutableVirtualizedList/EmptyVirtualizedList.js
@@ -73,11 +73,7 @@ class EmptyVirtualizedList extends PureComponent {
     const { renderEmpty, renderEmptyInList, ...passThroughProps } = this.props;
 
     return (
-      <ImmutableVirtualizedList
-        renderItem={() => this.renderItem()}
-        {...passThroughProps}
-        immutableData={listData}
-      />
+      <ImmutableVirtualizedList renderItem={() => this.renderItem()} {...passThroughProps} immutableData={listData} />
     );
   }
 

--- a/src/ImmutableVirtualizedList/EmptyVirtualizedList.js
+++ b/src/ImmutableVirtualizedList/EmptyVirtualizedList.js
@@ -73,7 +73,11 @@ class EmptyVirtualizedList extends PureComponent {
     const { renderEmpty, renderEmptyInList, ...passThroughProps } = this.props;
 
     return (
-      <ImmutableVirtualizedList renderItem={() => this.renderItem()} {...passThroughProps} immutableData={listData} />
+      <ImmutableVirtualizedList
+        renderItem={() => this.renderItem()}
+        {...passThroughProps}
+        immutableData={listData}
+      />
     );
   }
 

--- a/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
+++ b/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
@@ -107,17 +107,21 @@ class ImmutableVirtualizedList extends PureComponent {
   }
 
   render() {
-    const { immutableData } = this.props;
+    const { immutableData, renderEmpty, renderEmptyInList, ...passThroughProps } = this.props;
 
-    return this.renderEmpty() || (
-      <VirtualizedList
-        ref={(component) => { this.virtualizedListRef = component; }}
-        data={immutableData}
-        getItem={(items, index) => utils.getValueFromKey(index, items)}
-        getItemCount={(items) => (items.size || 0)}
-        keyExtractor={(item, index) => String(index)}
-        {...this.props}
-      />
+    return (
+      this.renderEmpty() || (
+        <VirtualizedList
+          ref={(component) => {
+            this.virtualizedListRef = component;
+          }}
+          data={immutableData}
+          getItem={(items, index) => utils.getValueFromKey(index, items)}
+          getItemCount={(items) => items.size || 0}
+          keyExtractor={(item, index) => String(index)}
+          {...passThroughProps}
+        />
+      )
     );
   }
 

--- a/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
+++ b/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
@@ -109,19 +109,15 @@ class ImmutableVirtualizedList extends PureComponent {
   render() {
     const { immutableData, renderEmpty, renderEmptyInList, ...passThroughProps } = this.props;
 
-    return (
-      this.renderEmpty() || (
-        <VirtualizedList
-          ref={(component) => {
-            this.virtualizedListRef = component;
-          }}
-          data={immutableData}
-          getItem={(items, index) => utils.getValueFromKey(index, items)}
-          getItemCount={(items) => items.size || 0}
-          keyExtractor={(item, index) => String(index)}
-          {...passThroughProps}
-        />
-      )
+    return this.renderEmpty() || (
+      <VirtualizedList
+        ref={(component) => { this.virtualizedListRef = component; }}
+        data={immutableData}
+        getItem={(items, index) => utils.getValueFromKey(index, items)}
+        getItemCount={(items) => (items.size || 0)}
+        keyExtractor={(item, index) => String(index)}
+        {...passThroughProps}
+      />
     );
   }
 

--- a/src/ImmutableVirtualizedList/__tests__/__snapshots__/EmptyVirtualizedList.test.js.snap
+++ b/src/ImmutableVirtualizedList/__tests__/__snapshots__/EmptyVirtualizedList.test.js.snap
@@ -16,15 +16,6 @@ exports[`EmptyVirtualizedList renders with custom renderRow 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        undefined,
-        "Nothing. Nothing at all.",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -35,7 +26,6 @@ exports[`EmptyVirtualizedList renders with custom renderRow 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -75,15 +65,6 @@ exports[`EmptyVirtualizedList renders with custom text 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        undefined,
-        "Nothing. Nothing at all.",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -94,7 +75,6 @@ exports[`EmptyVirtualizedList renders with custom text 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -140,15 +120,6 @@ exports[`EmptyVirtualizedList renders with default text 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        undefined,
-        "No data.",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -159,7 +130,6 @@ exports[`EmptyVirtualizedList renders with default text 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}

--- a/src/ImmutableVirtualizedList/__tests__/__snapshots__/ImmutableVirtualizedList.test.js.snap
+++ b/src/ImmutableVirtualizedList/__tests__/__snapshots__/ImmutableVirtualizedList.test.js.snap
@@ -13,13 +13,6 @@ exports[`ImmutableVirtualizedList renders basic List 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -30,7 +23,6 @@ exports[`ImmutableVirtualizedList renders basic List 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -85,7 +77,6 @@ exports[`ImmutableVirtualizedList renders basic Range 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={Immutable.Seq […]}
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -96,7 +87,6 @@ exports[`ImmutableVirtualizedList renders basic Range 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -162,18 +152,6 @@ exports[`ImmutableVirtualizedList renders nested List 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Array [
-        "so",
-        "are",
-      ],
-      Array [
-        "nested",
-        "lists",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -184,7 +162,6 @@ exports[`ImmutableVirtualizedList renders nested List 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -236,15 +213,6 @@ exports[`ImmutableVirtualizedList renders with empty data 1`] = `
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        "No data.",
-        "No data.",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -255,7 +223,6 @@ exports[`ImmutableVirtualizedList renders with empty data 1`] = `
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -292,7 +259,6 @@ exports[`ImmutableVirtualizedList with renderEmpty doesn't render empty with nul
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={Immutable.List []}
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -303,8 +269,6 @@ exports[`ImmutableVirtualizedList with renderEmpty doesn't render empty with nul
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmpty={null}
-  renderEmptyInList={null}
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -359,13 +323,6 @@ exports[`ImmutableVirtualizedList with renderEmpty renders normally when there a
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -376,8 +333,6 @@ exports[`ImmutableVirtualizedList with renderEmpty renders normally when there a
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmpty={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -432,7 +387,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList doesn't render empty wi
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={Immutable.List []}
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -443,8 +397,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList doesn't render empty wi
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmpty={null}
-  renderEmptyInList={null}
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -471,15 +423,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList renders empty with a fu
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        [Function],
-        "No data.",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -490,7 +433,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList renders empty with a fu
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -535,15 +477,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList renders empty with a st
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      Immutable.List [
-        undefined,
-        "No items",
-        "No items",
-      ],
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -554,7 +487,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList renders empty with a st
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList="No data."
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
@@ -597,13 +529,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList renders normally when t
   getItem={[Function]}
   getItemCount={[Function]}
   horizontal={false}
-  immutableData={
-    Immutable.List [
-      "lists",
-      "are",
-      "great",
-    ]
-  }
   initialNumToRender={10}
   keyExtractor={[Function]}
   maxToRenderPerBatch={10}
@@ -614,7 +539,6 @@ exports[`ImmutableVirtualizedList with renderEmptyInList renders normally when t
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderEmptyInList={[Function]}
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}


### PR DESCRIPTION
Currently, the following warnings are printed:
- Unknown props `immutableData`, `renderEmpty`, `rowsDuringInteraction`, `sectionHeaderHasChanged`, `renderEmptyInList` on `<div>` tag. Remove these props from the element.
- Unknown prop `emptyText` on `<div>` tag. Remove this prop from the element.

These changes pass only the necessary props to the components.