### PR TITLE
fixed error when items is null

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "src"
   ],
   "scripts": {
-    "prepare":"npm run build",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx",
     "clean": "rm -rf lib",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "src"
   ],
   "scripts": {
+    "install":"npm run build",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx",
     "clean": "rm -rf lib",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "scripts": {
-    "install":"npm run build",
+    "prepare":"npm run build",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx",
     "clean": "rm -rf lib",

--- a/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
+++ b/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
@@ -114,7 +114,7 @@ class ImmutableVirtualizedList extends PureComponent {
         ref={(component) => { this.virtualizedListRef = component; }}
         data={immutableData}
         getItem={(items, index) => utils.getValueFromKey(index, items)}
-        getItemCount={(items) => (items ? items.size || 0 : 0)}
+        getItemCount={(items) => ((items && items.size) || 0)}
         keyExtractor={(item, index) => String(index)}
         {...passThroughProps}
       />

--- a/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
+++ b/src/ImmutableVirtualizedList/ImmutableVirtualizedList.js
@@ -114,7 +114,7 @@ class ImmutableVirtualizedList extends PureComponent {
         ref={(component) => { this.virtualizedListRef = component; }}
         data={immutableData}
         getItem={(items, index) => utils.getValueFromKey(index, items)}
-        getItemCount={(items) => (items.size || 0)}
+        getItemCount={(items) => (items ? items.size || 0 : 0)}
         keyExtractor={(item, index) => String(index)}
         {...passThroughProps}
       />


### PR DESCRIPTION
in ImmutableVirtualizedList.js , in `getItemCount` when `items` is null throw error. With this change, at first it will checks `items` is valid and so on.