### PR TITLE
fix: add index.d.ts to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "files": [
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
It seems that `index.d.ts` is missing on npm. I think it's because the file is missing in the `files` section. Could you please cross check and republish? Thanks!